### PR TITLE
developer reference

### DIFF
--- a/pages/docs/_meta.json
+++ b/pages/docs/_meta.json
@@ -5,7 +5,7 @@
   "visualizing-data": { "title": "Data Explorer" },
   "sharing-data-externally": { "title": "Sharing Data Externally" },
   "dashboards": { "title": "Dashboards" },
-  "data-ops": { "title": "Data Ops" },
+  "data-ops": { "title": "Developer Reference" },
   "project-management": { "title": "Project Management" },
   "guides": { "title": "Guides" }
 }

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -110,7 +110,7 @@ export default {
     "https://github.com/glean-io/documentation/tree/main/",
   darkMode: false,
   nextThemes: { defaultTheme: 'light' },
-  primaryHue: 38,
+  primaryHue: 189,
   sidebar: { defaultMenuCollapseLevel: 4, toggleButton: true },
   head: function useHead() {
     const { title } = useConfig();


### PR DESCRIPTION
- change primary hue of docs, might want to tweak the link colors and some other default colors
- change 'data ops' to 'developer reference'

<img width="1336" alt="Screenshot 2023-08-30 at 11 48 57 AM" src="https://github.com/hashboard-hq/documentation/assets/200008/37568dcc-0fe5-4c69-a7e8-f7f9c88e81e2">
