### PR TITLE
[GL-6585] hashboard_access_key -> hb_access_key

### DIFF
--- a/pages/docs/data-ops/cli/token.mdx
+++ b/pages/docs/data-ops/cli/token.mdx
@@ -6,7 +6,7 @@ The token command lets you authenticate the CLI.  You can also go to your [`Sett
 hb token
 ```
 
-By default, the CLI expects your Access Key to be located at `~/.hashboard/hashboard_access_key.json`. You can override this by:
+By default, the CLI expects your Access Key to be located at `~/.hashboard/hb_access_key.json`. You can override this by:
 
 - Setting the `HASHBOARD_CREDENTIALS_FILEPATH` environment variable to a different filepath
 - Using the `--credentials-filepath` command-line option to use a different filepath

--- a/pages/docs/data-ops/quickstart.mdx
+++ b/pages/docs/data-ops/quickstart.mdx
@@ -19,7 +19,7 @@ First signup for an account by clicking 'get access' on [hashboard.com](https://
 hb signup
 ```
 
-The `token` command will take you through a web-based auth flow and download your access token to the default token location at ~/.hashboard/hashboard_access_key.json - you can also specify the token location with the environment variable `HASHBOARD_CREDENTIALS_FILEPATH`.
+The `token` command will take you through a web-based auth flow and download your access token to the default token location at ~/.hashboard/hb_access_key.json - you can also specify the token location with the environment variable `HASHBOARD_CREDENTIALS_FILEPATH`.
 
 ```bash filename="if you signed up on the web" copy
 hb token


### PR DESCRIPTION
In the code, DEFAULT_CREDENTIALS_FILEPATH is defined as ~/.hashboard/hb_access_key, but in our documentation, we were saying our default file name was hashboard_access_key. This changes it to reflect the code.