### PR TITLE
Normalize references to CLI commands in documentation.

### DIFF
--- a/pages/docs/data-ops/cli.mdx
+++ b/pages/docs/data-ops/cli.mdx
@@ -84,8 +84,7 @@ Check out the [Quickstart guide](quickstart) to learn how to set up your CLI cli
 The CLI allows you to integrate Hashboard into your existing development and deployment process. As an example, below is a recommended workflow for making changes to Hashboard resources or upstream data:
 
 1. Store your Hashboard configuration files in a git repo alongside your data pipeline code.
-2. Run your pipelines to populate test data into a separate database or schema.
-   a. If you use dbt for your data pipline check out the [dbt integration]() documentation to see how to seamlessly combine your dbt and Hashboard workflows
+2. Run your pipelines to populate test data into a separate database or schema. If you use dbt for your data pipline check out the [dbt integration]() documentation to see how to seamlessly combine your dbt and Hashboard workflows.
 3. Adjust your Hashboard [configuration files]() as necessary to reflect your intended changes.
 4. Run `hb preview` to create a [Preview Build](), adjusting the `source` section of your model(s) to point at your test dataset.
 5. Make any necessary adjustments in the Preview and re-export your new configuration files.

--- a/pages/docs/data-ops/cli/cache.mdx
+++ b/pages/docs/data-ops/cli/cache.mdx
@@ -1,8 +1,8 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# Hashboard cache command
+# `cache`
 
-The cache command allows you fine grained control of the data cached in Hashboard.
+The `cache` command allows you fine grained control of the data cached in Hashboard.
 
 ## Clearing the cache
 
@@ -10,7 +10,6 @@ If you've just updated a specific data model and want to ensure that all users v
 
 ```bash copy
 hb cache clear m:MODEL_ID
-
 ```
 
 To learn more about caching in Hashboard and how to control cache behavior via the GUI visit the Hashboard [caching reference](/docs/data-modeling/caching).

--- a/pages/docs/data-ops/cli/cache.mdx
+++ b/pages/docs/data-ops/cli/cache.mdx
@@ -1,6 +1,6 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# `cache`
+# Hashboard `cache` command
 
 The `cache` command allows you fine grained control of the data cached in Hashboard.
 

--- a/pages/docs/data-ops/cli/credentials.mdx
+++ b/pages/docs/data-ops/cli/credentials.mdx
@@ -1,4 +1,4 @@
-# CLI Credentials
+# Credentials
 
 The CLI is authenticated by an access key. To create a new access key, run the [`token`](/docs/data-ops/cli/token) command or go to 
 your [`Settings`](https://hashboard.com/app/p/settings#access_keys) in the web UI.

--- a/pages/docs/data-ops/cli/databases.mdx
+++ b/pages/docs/data-ops/cli/databases.mdx
@@ -1,8 +1,8 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# Hashboard databases command
+# `databases`
 
-The databases command allows you to see a list of all available database connections when developing Hashboard resources via the CLI.
+The `databases` command allows you to see a list of all available database connections when developing Hashboard resources via the CLI.
 
 ```bash copy
 hb databases
@@ -17,4 +17,4 @@ Successfully logged in to Pizza Bytes
 
 ```
 
-You can explore connections further using the [tables command](./tables) and upload files directly to Hashboard using the [upload command](./upload). To configure new connections check out the [Hashboard guide](/docs/database-connections) for connecting to your database.
+You can explore connections further using the [`tables`](./tables) command and upload files directly to Hashboard using the [`upload`](./upload) command. To configure new connections check out the [Hashboard guide](/docs/database-connections) for connecting to your database.

--- a/pages/docs/data-ops/cli/databases.mdx
+++ b/pages/docs/data-ops/cli/databases.mdx
@@ -1,6 +1,6 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# `databases`
+# Hashboard `databases` command
 
 The `databases` command allows you to see a list of all available database connections when developing Hashboard resources via the CLI.
 

--- a/pages/docs/data-ops/cli/deploy.mdx
+++ b/pages/docs/data-ops/cli/deploy.mdx
@@ -1,6 +1,6 @@
 import { Cards, Card } from 'nextra-theme-docs'
 
-# `deploy`
+# Hashboard `deploy` command
 
 The `deploy` command will update your Hashboard project with changes in your local configuration files.
 

--- a/pages/docs/data-ops/cli/deploy.mdx
+++ b/pages/docs/data-ops/cli/deploy.mdx
@@ -1,10 +1,10 @@
 import { Cards, Card } from 'nextra-theme-docs'
 
-# Deploy
+# `deploy`
 
-Deploy will update your Hashboard project with changes in your local configuration files.
+The `deploy` command will update your Hashboard project with changes in your local configuration files.
 
-The `deploy` command works with dbt and git workflows:
+`hb deploy` works with dbt and Git workflows:
 <br />
 <Cards>
   <Card arrow icon=" " title="dbt workflows" href="/docs/data-ops/dbt-integration" />

--- a/pages/docs/data-ops/cli/preview.mdx
+++ b/pages/docs/data-ops/cli/preview.mdx
@@ -1,15 +1,15 @@
 import { Cards, Card, Steps } from 'nextra-theme-docs'
 
-# Hashboard preview command
+# `preview`
 
-The preview command in Hashboard is a safe way to see what Hashboard configuration files will look like inside of Hashboard without affecting the state of the BI tool.  Preview makes forking and experimenting with Hashboard from the command line cheap and easy.  A preview goes through the following steps:
+The `preview` command is a safe way to see what Hashboard configuration files will look like inside of Hashboard without affecting the state of the BI tool. `hb preview` makes forking and experimenting with Hashboard from the command line cheap and easy.  A preview goes through the following steps:
 
 1. Validates local Hashboard configuration files and dbt configuration (if using `--dbt`)
 2. Validates that the data warehouse schema is in sync with your data models
 3. Creates a copy of your main project and puts it into a safe, containerized preview of your local changes and provides you a link to this forked version of your project
 4. Provides you with a list of all managed resources that are changed—either created, updated, deleted or unchanged
 
-The `preview` command works with dbt and git workflows.
+The `preview` command works with dbt and Git workflows.
 <br />
 <Cards>
   <Card arrow icon=" " title="dbt workflows" href="/docs/data-ops/dbt-integration" />
@@ -55,7 +55,7 @@ Unchanged:
 Details: https://hashboard.com/app/p/builds/16LDUF46wuCwM8B2
 ```
 
-### open the build
+### Open the build
 
 Go to the build preview link at the bottom of the build details, for example `https://hashboard.com/app/p/builds/16LDUF46wuCwM8B2`. The build preview gives a list of resources with preview links.
 <br />
@@ -63,9 +63,9 @@ Go to the build preview link at the bottom of the build details, for example `ht
 <img src="/build.png" style={{maxWidth: "600px" }} />
 
 
-### navigate resource previews
+### Navigate resource previews
 
-Click any resource to open the preview and start to explore.  The build is added as a url parameter so you can share links (or post them to PRs etc.).  You can navigate through your entire project in the preview mode.
+Click any resource to open the preview and start to explore.  The build is added as a URL query parameter so you can share links (or put them in pull requests, for example).  You can navigate through your entire project in the preview mode.
 
 <br />
 

--- a/pages/docs/data-ops/cli/preview.mdx
+++ b/pages/docs/data-ops/cli/preview.mdx
@@ -1,6 +1,6 @@
 import { Cards, Card, Steps } from 'nextra-theme-docs'
 
-# `preview`
+# Hashboard `preview` command
 
 The `preview` command is a safe way to see what Hashboard configuration files will look like inside of Hashboard without affecting the state of the BI tool. `hb preview` makes forking and experimenting with Hashboard from the command line cheap and easy.  A preview goes through the following steps:
 

--- a/pages/docs/data-ops/cli/pull.mdx
+++ b/pages/docs/data-ops/cli/pull.mdx
@@ -1,26 +1,28 @@
 import { Callout } from "nextra-theme-docs";
 
-# Hashboard pull command
+# `pull`
 
-`hb pull` is a utility for getting resource configuration files from the web UI to a local workspace. You can use it to migrate resources to a code-based workflow. If you already have local files that correspond with Hashboard resources, `hb pull` will update the local versions of those files.
+The `pull` command is a utility for getting resource configuration files from the web UI to a local workspace. You can use it to migrate resources to a code-based workflow. If you already have local files that correspond with Hashboard resources, `hb pull` will update the local versions of those files.
 
-## Update resources and dev workflow
+## Updating resources and dev workflow
 
-The default behavior of `pull` is to only update resources that were created with the `hb` command. For example, if you originally built four models with the `hb` command and you run `hb pull` from an empty directory, you'll only pull those four model files. You won't get any additional resources built in the UI.
+The default behavior of `pull` is to only update resources that were created through the Hashboard CLI (i.e. any `hb` command).
+
+For example: let's say you originally built four models with the CLI and another two models in the UI. If you run `hb pull` from an empty directory, you'll only pull those four model files. You won't get the two UI-built models, or any additional resources built in the UI for that matter.
 
 ## `pull` resources originally built in the UI
 
-You can also pull resources that were not built with the `hb` command. If you want to pull down a resource that was built in the UI, you have two options:
+You can also pull resources that were not built with the CLI. If you want to pull down a resource that was built in the UI, you have two options:
 
-### 1. pull every resource with `--all`
+### 1. Pull all resources
 
-You can use the all flag to get ever single Hashboard resource, regardless of whether it was created with the `hb` command or not.
+You can use the `--all` flag to get every single Hashboard resource regardless of whether it was created with the CLI.
 
 ```bash copy
 hb pull --all
 ```
 
-### 2. pull a specific resource with a GRN
+### 2. Pull a specific resource with a GRN
 
 You can pull down a specific resource by its [Global Resource Name](/docs/data-ops/resource-identifiers).
 
@@ -36,14 +38,18 @@ You can pull down a specific resource by its [Global Resource Name](/docs/data-o
 # pull by a specific grn
 hb pull m:s3AdinvBhsdJ:
 
-## or pull by alias
+# alternatively, pull by alias
 hb pull m::my_sales_model
 ```
 
-## Managing dbt state with pull
+## Managing dbt state with `pull`
 
-The behavior of Hashboard pull is a bit different when used for dbt models. We cannot update models automatically inside of dbt files (since there could be jinja that we can't decompile). Instead of updating resources in place, we'll create new model files outside of your dbt project. This lets you to inspect the configuration and merge it into your dbt files.
+The behavior of `hb pull` is a bit different when used for dbt models. We cannot update models automatically inside of dbt files (since there could be jinja that we can't decompile).
+
+Instead of updating resources in place, we'll create new model files outside of your dbt project. This lets you inspect the configuration and merge it into your dbt files.
 
 ## Config format used in `pull`
 
-Hashboard pull uses the most verbose (and specific) possible format of a resource. Some configuration that is just defaulted or configured by Hashboard will be exported. For example, if you export a resource it will default to being exported with a `pinned` grn. You can remove the grn to allow you to deploy the resource across different projects (or use an alias so that the resource is not bound to a specific instance in a single project).
+`hb pull` uses the most verbose (and specific) possible format of a resource. Some configuration that is just defaulted or configured by Hashboard will be exported.
+
+For example: if you export a resource, it will default to being exported with a `pinned` [GRN](/docs/data-ops/resource-identifiers). You can remove the GRN to enable deploying the resource across different projects (or use an alias so that the resource is not bound to a specific instance in a single project).

--- a/pages/docs/data-ops/cli/pull.mdx
+++ b/pages/docs/data-ops/cli/pull.mdx
@@ -1,6 +1,6 @@
 import { Callout } from "nextra-theme-docs";
 
-# `pull`
+# Hashboard `pull` command
 
 The `pull` command is a utility for getting resource configuration files from the web UI to a local workspace. You can use it to migrate resources to a code-based workflow. If you already have local files that correspond with Hashboard resources, `hb pull` will update the local versions of those files.
 

--- a/pages/docs/data-ops/cli/tables.mdx
+++ b/pages/docs/data-ops/cli/tables.mdx
@@ -1,8 +1,8 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# Hashboard tables command
+# `tables`
 
-The tables command allows you to see a list of all available tables within a specific database when developing Hashboard resources via the CLI. To see the names of the database connections available in your project use the [databases command](./databases)
+The `tables` command allows you to see a list of all available tables within a specific database when developing Hashboard resources via the CLI. To see the names of the database connections available in your project use the [`databases`](./databases) command.
 
 ```bash copy
 hb tables [database connection name]
@@ -19,4 +19,4 @@ Successfully logged in to Pizza Bytes
 
 ```
 
-These tables can be referenced when building out [model configurations](/docs/data-ops/config-schema/data-models). If you have a DuckDB connection you can upload files to use as tables directly from the CLI using the [upload command](./upload)
+These tables can be referenced when building out [model configurations](/docs/data-ops/config-schema/data-models). If you have a DuckDB connection you can upload files to use as tables directly from the CLI using the [`upload`](./upload) command.

--- a/pages/docs/data-ops/cli/tables.mdx
+++ b/pages/docs/data-ops/cli/tables.mdx
@@ -1,6 +1,6 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# `tables`
+# Hashboard `tables` command
 
 The `tables` command allows you to see a list of all available tables within a specific database when developing Hashboard resources via the CLI. To see the names of the database connections available in your project use the [`databases`](./databases) command.
 

--- a/pages/docs/data-ops/cli/token.mdx
+++ b/pages/docs/data-ops/cli/token.mdx
@@ -1,4 +1,4 @@
-# Hashboard token command
+# `token`
 
 The `token` command lets you authenticate the CLI. It will take you through a web-based authentication flow and download a new access key for you.
 

--- a/pages/docs/data-ops/cli/token.mdx
+++ b/pages/docs/data-ops/cli/token.mdx
@@ -1,4 +1,4 @@
-# `token`
+# Hashboard `token` command
 
 The `token` command lets you authenticate the CLI. It will take you through a web-based authentication flow and download a new access key for you.
 

--- a/pages/docs/data-ops/cli/upload.mdx
+++ b/pages/docs/data-ops/cli/upload.mdx
@@ -1,8 +1,8 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# Hashboard upload command
+# `upload`
 
-The upload command allows you to upload files directly to Hashboard that can be queried using [DuckDB](/docs/database-connections/duckdb) and used as the
+The `upload` command allows you to upload files directly to Hashboard that can be queried using [DuckDB](/docs/database-connections/duckdb) and used as the
 basis for a data model.
 
 ```bash copy

--- a/pages/docs/data-ops/cli/upload.mdx
+++ b/pages/docs/data-ops/cli/upload.mdx
@@ -1,6 +1,6 @@
 import { Callout, Steps } from "nextra-theme-docs";
 
-# `upload`
+# Hashboard `upload` command
 
 The `upload` command allows you to upload files directly to Hashboard that can be queried using [DuckDB](/docs/database-connections/duckdb) and used as the
 basis for a data model.

--- a/pages/docs/data-ops/managing-resources-with-code.mdx
+++ b/pages/docs/data-ops/managing-resources-with-code.mdx
@@ -26,7 +26,7 @@ Full documentation of all configuration files can be found for each resource typ
 - [Homepage Launchpad](/docs/data-ops/config-schema/Homepage-Launchpad)
 
 <Callout type="info">
-  **Exporting configuration files** - use the [hb pull](/docs/data-ops/cli/pull)
+  To export configuration files, use the [`pull`](/docs/data-ops/cli/pull)
   command.
 </Callout>
 
@@ -46,4 +46,4 @@ To protect specific resources to only be editable with the Hashboard deployments
 
 ### Syncing resources
 
-To sync your local config files with edits made to resources via the UI, use the [pull command](/docs/data-ops/cli/pull).
+To sync your local config files with edits made to resources via the UI, use the [`pull`](/docs/data-ops/cli/pull) command.

--- a/pages/docs/data-ops/quickstart.mdx
+++ b/pages/docs/data-ops/quickstart.mdx
@@ -32,7 +32,7 @@ the default filepath `~/.hashboard/hb_access_key.json`.
 hb token
 ```
 
-For information about how to store this token at a different filepath, see the `token` [documentation](/docs/data-ops/cli/token).
+For information about how to store this token at a different filepath, see the [`token`](/docs/data-ops/cli/token) documentation.
 
 ### Set up integrations
 
@@ -40,7 +40,7 @@ Hashboard integrates seamlessly with other tools so you can easily manage your d
 
 ### Pull resources or build a sample project
 
-If you've created data models, saved explorations or dashboards via the Hashboard GUI you can get started iterating on those resources as code using the [pull command](./cli/pull). `hb pull --all` will pull the configs of all resources in your project into your current directory.
+If you've created data models, saved explorations or dashboards via the Hashboard GUI you can get started iterating on those resources as code using the [`pull`](./cli/pull) command. `hb pull --all` will pull the configs of all resources in your project into your current directory.
 
 ```bash copy
 hb pull --all
@@ -54,7 +54,7 @@ You can now edit your resources as code and check them into Git for version cont
 
 ### Deploy your changes
 
-Use the [deploy command](./cli/deploy) to write your changes back to your Hashboard project. By default you'll be able to [preview](./cli/preview) your changes before they're published.
+Use the [`deploy`](./cli/deploy) command to write your changes back to your Hashboard project. By default you'll be able to [`preview`](./cli/preview) your changes before they're published.
 
 ```bash copy
 hb deploy


### PR DESCRIPTION
...and any other typos I found along the way.