### PR TITLE
Update product roadmap in docs to iframe our public roadmap

### DIFF
--- a/components/Iframe.tsx
+++ b/components/Iframe.tsx
@@ -6,6 +6,6 @@ type IframeProps = { src: string } & HTMLAttributes<HTMLIFrameElement>;
 
 export default function Iframe(props: IframeProps) {
   return (
-    <iframe width="100%" height="500px" style={{ border: "none" }} {...props} />
+    <iframe width="100%" height="500px" {...props} />
   );
 }

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -7,6 +7,7 @@
     "title": "Roadmap",
     "type": "page",
      "theme": {
+      "layout": "full",
       "breadcrumb": false,
       "footer": false,
       "sidebar": false,

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -5,7 +5,14 @@
   },
   "product-roadmap": {
     "title": "Roadmap",
-    "type": "page"
+    "type": "page",
+     "theme": {
+      "breadcrumb": false,
+      "footer": false,
+      "sidebar": false,
+      "toc": false,
+      "pagination": false
+    }
   },
   "changelog": {
     "title": "Changelog",

--- a/pages/product-roadmap.mdx
+++ b/pages/product-roadmap.mdx
@@ -1,9 +1,8 @@
 import Iframe from "/components/Iframe";
 
+<br />
+<center>
 # Product Roadmap
-
-Check out the [changelog](/changelog) to see what we've shipped recently 🚀
-
-👀 Hoping to see something else here? [Let us know](mailto:support@hashboard.com) what we’re missing.
-
+</center>
+<br />
 <Iframe src="https://hashboard.com/roadmap-iframe" height="1200px"/>

--- a/pages/product-roadmap.mdx
+++ b/pages/product-roadmap.mdx
@@ -1,44 +1,9 @@
+import Iframe from "/components/Iframe";
+
 # Product Roadmap
 
 Check out the [changelog](/changelog) to see what we've shipped recently 🚀
 
 👀 Hoping to see something else here? [Let us know](mailto:support@hashboard.com) what we’re missing.
 
-## In progress
-
-In the next six weeks:
-
-- <del>Array attributes</del> [launched June](/changelog/2023_06_30#filter-and-group-array-values)
-- <del>Description syncing</del> [launched June](/changelog/2023_06_30#documentation-synced-from-dbt-and-your-warehouse)
-- <del>Dual y-axis charts</del> [launched June](/changelog/2023_06_30#bar--line-charts-and-more)
-- <del>Pull command in the CLI</del> [launched June](/changelog/2023_06_30#improved-dataops-workflow-with-hashboard-pull)
-- <del>Bar and line charts</del> [launched June](/changelog/2023_06_30#bar--line-charts-and-more)
-- <del>ClickHouse integration</del> [launched June](/changelog/2023_06_30#-other-updates-blog-posts--more)
-- <del>Hashboard models built from dbt Files</del> [launched July](/docs/data-ops/dbt-integration)
-- <del>Model joining</del> [launched August](/docs/data-modeling/model-joins)
-- <del>Much better data search</del> [launched September](/docs/visualizing-data/quick-explore)
--  <del>Data library with metrics page</del> [launched September](/docs/metrics)
-- <del>New data tray in model explorer</del> [launched August](/docs/visualizing-data/data-tray)
-
-## Up next
-
-In the next few months:
-
-- Model hopping
-- Derived measures and attributes
-- Post-aggregation joining
-- Enhanced pivot tables
-- Enhanced tables
-- Production tag
-- Trino integration
-- Databricks integration
-
-## On the horizon
-
-Future features under consideration:
-
-- Collections in the Hashboard config spec
-- More advanced calculations
-- Enhanced real-time collaboration
-- Inline annotations
-- Self-service sign up
+<Iframe src="https://hashboard.com/roadmap-iframe" height="1200px"/>


### PR DESCRIPTION
Closes GRO-42

We're hosting our our public roadmap here: https://hashboard.com/roadmap-iframe

The idea was to just iframe it on our public roadmap.  Formatting isn't quite right yet.