### PR TITLE
Add MotherDuck connection docs and fix up connection docs to reflect new 'Data sources' page.

### DIFF
--- a/pages/docs/database-connections.mdx
+++ b/pages/docs/database-connections.mdx
@@ -28,13 +28,12 @@ Fill out the remaining credentials as they'll be accessed by your bastion host, 
 
 ## Create a database connection
 
-1. Go to the [`Settings`](https://hashboard.com/app/p/settings#database_connections) page using the link in the project dropdown
-2. Select `Database Connections`
-3. Click `+ Add Database Connection`
-4. Select the type of database
-5. Fill out the credentials according to your type of database
-6. Click the antenna icon to test your connection `🗼`
-7. Click `Add` to complete the process
+1. Go to the [Data sources](https://hashboard.com/app/p/data-sources) page using the link in the project dropdown
+2. Click `+ Add connection`
+3. Select the type of database
+4. Fill out the credentials according to your type of database
+5. Click the antenna icon to test your connection `🗼`
+6. Click `Add` to complete the process
 
 <Callout type="info" emoji="✏️">
   **Specifying Schemas** For most database types, you can optionally specify a

--- a/pages/docs/database-connections/_meta.json
+++ b/pages/docs/database-connections/_meta.json
@@ -14,8 +14,8 @@
   "duckdb": {
     "title": "DuckDB"
   },
-  "mysql": {
-    "title": "MySQL"
+  "motherduck": {
+    "title": "MotherDuck"
   },
   "postgresql": {
     "title": "PostgreSQL"

--- a/pages/docs/database-connections/athena.mdx
+++ b/pages/docs/database-connections/athena.mdx
@@ -89,10 +89,8 @@ Hashboard's caching. Amazon has a few good articles on
 
 ## Create an Athena database connection in Hashboard
 
-1. First, go to your
-   [Hashboard settings](https://hashboard.com/app/p/settings#database_connections) page
-   from the project dropdown.
-2. Click `+ New Database Connection` and fill out the fields below.
+1. In Hashboard, go to the [Data sources](https://hashboard.com/app/p/data-sources) page.
+2. Click `+ Add connection`, select `Athena` and fill out the fields below.
 
 ### Settings
 

--- a/pages/docs/database-connections/bigquery.mdx
+++ b/pages/docs/database-connections/bigquery.mdx
@@ -50,10 +50,8 @@ account JSON key file into this field. See the
 
 ## Create BigQuery database connection in Hashboard
 
-1. First, go to your
-   [Hashboard settings](https://hashboard.com/app/p/settings#database_connections) page
-   from the project dropdown.
-2. Click `+ New Database Connection` and fill out the fields below.
+1. In Hashboard, go to the [Data sources](https://hashboard.com/app/p/data-sources) page.
+2. Click `+ Add connection`, select `BigQuery` and fill out the fields below.
 
 ### Settings
 

--- a/pages/docs/database-connections/clickhouse.mdx
+++ b/pages/docs/database-connections/clickhouse.mdx
@@ -26,8 +26,8 @@ If you have relatively small data or are very early, using something lightweight
 
 1. Set up a ClickHouse database, either by hosting it on your own infrastructure or signing up for [ClickHouse Cloud](https://clickhouse.com/).
 2. Set up a username and password for usage by Hashboard.
-3. In Hashboard, go to your [project settings](https://hashboard.com/app/p/settings#database_connections) page from the project dropdown and click `+ New Database Connection`.
-4. Change the datatabse type to "ClickHouse" and fill out the connection settings as described below.
+3. In Hashboard, go to the [Data sources](https://hashboard.com/app/p/data-sources) page.
+4. Click `+ Add connection`, select `ClickHouse` and fill out the fields below.
 
 ### Settings
 

--- a/pages/docs/database-connections/motherduck.mdx
+++ b/pages/docs/database-connections/motherduck.mdx
@@ -1,0 +1,23 @@
+---
+description: MotherDuck is a collaborative serverless analytics platform
+---
+
+# MotherDuck
+
+MotherDuck is a collaborative serverless analytics platform based on DuckDB, an analytics engine optimized for online analytical processing (OLAP)
+on your personal machine. MotherDuck enables hybrid execution across your machine and resources in the cloud by automatically planning each part
+of your query and determining where it's best computed.
+
+If you require analyzing datasets across multiple external sources in a quick and cost-effective way, MotherDuck could be a great solution.
+
+### How to get set up
+
+1. Follow MotherDuck's [documentation](https://motherduck.com/docs/category/getting-started) on getting started.
+2. In Hashboard, go to the [Data sources](https://hashboard.com/app/p/data-sources) page.
+3. Click `+ Add connection`, select `MotherDuck` and fill out the fields below.
+
+### Settings
+
+- **Connection Name:** A nickname for your connection. Not used to connect to your database.
+- **Database Name:** The name of the MotherDuck database to connect to.
+- **Service Token:** Your MotherDuck [service token](https://motherduck.com/docs/authenticating-to-motherduck/#fetching-the-service-token).

--- a/pages/docs/database-connections/mysql.mdx
+++ b/pages/docs/database-connections/mysql.mdx
@@ -18,8 +18,8 @@ Long term, we'd recommend eventually moving your analytics data to a modern data
 
 1. If you're using MySQL because that's what your application's backend is based on, make sure you're on a read-replica so your analytics queries don't bog down your application database.
 2. [Create a read-only user for Hashboard to use](https://dev.mysql.com/doc/refman/8.0/en/create-user.html) and grant it the appropriate permissions.
-3. Go to your [Hashboard settings](https://hashboard.com/app/p/settings#database_connections) page.
-4. Click `+ New Database Connection` and fill out the fields below.
+3. In Hashboard, go to the [Data sources](https://hashboard.com/app/p/data-sources) page.
+4. Click `+ Add connection`, select `MySQL` and fill out the fields below.
 
 ### Settings
 

--- a/pages/docs/database-connections/postgresql.mdx
+++ b/pages/docs/database-connections/postgresql.mdx
@@ -22,9 +22,8 @@ If you're starting off with a copy of your application database, there's a high 
 
 1. We recommend [creating a separate user for Hashboard](https://www.postgresql.org/docs/current/sql-createuser.html) to use in order to easily track usage and performance.
 2. Grant the user the appropriate [roles](https://www.postgresql.org/docs/current/role-membership.html) needed to query your analytics data.
-3. Set up a connection in Hashboard:
-   1. First, go to your [Hashboard settings](https://hashboard.com/app/p/settings#database_connections) page from the project dropdown.
-   2. Click `+ New Database Connection` and fill out the fields below.
+3. In Hashboard, go to the [Data sources](https://hashboard.com/app/p/data-sources) page.
+4. Click `+ Add connection`, select `PostgreSQL / Redshift` and fill out the fields below.
 
 ### Settings
 

--- a/pages/docs/database-connections/snowflake.mdx
+++ b/pages/docs/database-connections/snowflake.mdx
@@ -51,8 +51,8 @@ grant SELECT on future tables in database identifier($database_name) to role ide
 
 ## Create a Snowflake database connection in Hashboard
 
-1. First, go to your [Hashboard settings](https://hashboard.com/app/p/settings#database_connections) page from the project dropdown
-2. Click `+ New Database Connection` and fill out the fields below
+1. In Hashboard, go to the [Data sources](https://hashboard.com/app/p/data-sources) page.
+2. Click `+ Add connection`, select `Snowflake` and fill out the fields below.
 
 ### Settings
 


### PR DESCRIPTION
☝️ 

Our data connection docs pointed to the wrong place since `Data sources` became its own page.