### PR TITLE
update script for permissions in snowflake docs

### DIFF
--- a/pages/docs/database-connections/snowflake.mdx
+++ b/pages/docs/database-connections/snowflake.mdx
@@ -45,8 +45,11 @@ to role identifier($hashboard_role);
 -- grant Hashboard access to database
 grant MONITOR, USAGE  on database identifier($database_name) to role identifier($hashboard_role);
 grant USAGE on all schemas in database identifier($database_name) to role identifier($hashboard_role);
+grant USAGE on future schemas in database identifier($database_name) to role identifier($hashboard_role);
 grant SELECT on all tables in database identifier($database_name) to role identifier($hashboard_role);
 grant SELECT on future tables in database identifier($database_name) to role identifier($hashboard_role);
+grant SELECT on all views in database identifier($database_name) to role identifier($hashboard_role);
+grant SELECT on future views in database identifier($database_name) to role identifier($hashboard_role);
 ```
 
 ## Create a Snowflake database connection in Hashboard


### PR DESCRIPTION
We should grant all 'future' schemas (so newly created schemas are included in HASHBOARD_USERS's permissions) also add view permissions.