### PR TITLE
Rename archive status to deprecated

### DIFF
--- a/pages/docs/project-management/resource-metadata.mdx
+++ b/pages/docs/project-management/resource-metadata.mdx
@@ -23,7 +23,7 @@ Resource status allows you to easily convey the current state of a resource. The
 - Exploratory
 - In progress
 - Verified
-- Archive
+- Deprecated
 
 ### Owner
 The person responsible for overseeing and managing the resource is the resource owner.


### PR DESCRIPTION
This is a small change to reflect the rename of the "archive" status in the app. I will merge this when https://github.com/gleannyc/glean/pull/11095 is about to be deployed to prod.