### PR TITLE
Update metric / measure language on various pages

### DIFF
--- a/pages/docs/data-ops/config-schema/data-models.mdx
+++ b/pages/docs/data-ops/config-schema/data-models.mdx
@@ -7,14 +7,6 @@ import EmbedDocsFromHashboardApp from "/components/EmbedDocsFromHashboardApp";
 
 # Data Models
 
-<Callout type="warning">
-  Hashboard previously used the term **metric** to refer to what is now called a
-  **measure**. At the moment our configuration files still refer to `type:
-  metric` when creating measures inside a data model. We plan to update the
-  schema of these configuration files in the future to use the term **measure**
-  instead of **metric**.
-</Callout>
-
 <br />
 
 <EmbedDocsFromHashboardApp path="publicResourceSpecs/Model" />

--- a/pages/docs/data-ops/dbt-integration.mdx
+++ b/pages/docs/data-ops/dbt-integration.mdx
@@ -36,7 +36,7 @@ models:
 
 ### Define model information
 
-The simplest example of a Hashboard model just defines a measure.  Hashboard models must include the `hashboard` key in the dbt model.
+The simplest example of a Hashboard model just defines a measure. Hashboard models must include the `hashboard` key in the dbt model.
 
 ```yaml filename="models/schema.yml" copy
 version: 2
@@ -56,18 +56,10 @@ models:
       hashboard:
         cols:
           - id: row_count
-            type: metric
+            type: measure
             name: Order Attribution Records
             aggregate: row_count
 ```
-
-<Callout type="warning">
-  Hashboard previously used the term **metric** to refer to what is now called a
-  **measure**. At the moment our configuration files still refer to `type:
-  metric` when creating measures inside a data model. We plan to update the
-  schema of these configuration files in the future to use the term **measure**
-  instead of **metric**.
-</Callout>
 
 ### Build your Hashboard models
 
@@ -85,7 +77,7 @@ hb deploy --dbt
 
 ## Model specification
 
-The `hashboard-defaults` connection configuration in the example above gets merged into the Hashboard configuration inside each dbt model.  If you don't specify the defaults, you must add the complete connection information in the `meta` key of each dbt model you want imported to Hashboard.  Only dbt models that specify a `hashboard` key will get built into Hashboard models.  
+The `hashboard-defaults` connection configuration in the example above gets merged into the Hashboard configuration inside each dbt model. If you don't specify the defaults, you must add the complete connection information in the `meta` key of each dbt model you want imported to Hashboard. Only dbt models that specify a `hashboard` key will get built into Hashboard models.
 
 ```yaml filename="schema.yml" copy
 version: 2
@@ -105,6 +97,7 @@ models:
 ```
 
 Some notes on how models get built from dbt:
+
 - Hashboard will read the dbt manifest file and find all models with a `hashboard` key specified within the `meta` key.
 - The name of dbt model is imported into Hashboard as the model name (this can be overriden).
 - Columns specified explicitly in the dbt model will become attributes in Hashboard.
@@ -147,18 +140,10 @@ models:
       hashboard:
         cols:
           - id: daily_active_users
-            type: metric
+            type: measure
             name: Daily Active Users
             sql: COUNT(DISTINCT customer_id) / COUNT(DISTINCT create_at)
 ```
-
-<Callout type="warning">
-  Hashboard previously used the term **metric** to refer to what is now called a
-  **measure**. At the moment our configuration files still refer to `type:
-  metric` when creating measures inside a data model. We plan to update the
-  schema of these configuration files in the future to use the term **measure**
-  instead of **metric**.
-</Callout>
 
 Hashboard configuration in your dbt schema file has access to the same [templating and macros](https://docs.getdbt.com/docs/build/jinja-macros) as your dbt configuration. You could, for example, configure the Hashboard data connection based on your dbt target:
 

--- a/pages/docs/guides/prod-staging-environments.mdx
+++ b/pages/docs/guides/prod-staging-environments.mdx
@@ -43,17 +43,22 @@ You can also use any dbt jinja or dbt macros to templatize or switch between dif
   <Tab>
   ```yaml dbt_project.yml copy {11}
 
-models:
-+meta: # hashboard-defaults settings will be merged into each Hashboard model
-hashboard-defaults:
-hbVersion: "1.0" # preventUpdatesFromUI defaults to true, but can be set to false
-preventUpdatesFromUI: false
-source:
-connectionName: bigquery-prod # you could also toggle the db connection
-schema: "{{ target.schema }}" # or you could do an env variable: # schema: "{{ env_var('HB_SCHEMA_ENV') }}" # OR a macro: # schema: "{{ my_custom_macro(env) }}"
-
-```
-</Tab>
+  models:
+    +meta:
+      # hashboard-defaults settings will be merged into each Hashboard model
+      hashboard-defaults:
+        hbVersion: "1.0"
+        # preventUpdatesFromUI defaults to true, but can be set to false
+        preventUpdatesFromUI: false
+        source:
+          connectionName: bigquery-prod # you could also toggle the db connection
+          schema: "{{ target.schema }}"
+          # or you could do an env variable:
+          # schema: "{{ env_var('HB_SCHEMA_ENV') }}"
+          # OR a macro:
+          # schema: "{{ my_custom_macro(env) }}"
+  ```
+  </Tab>
 </Tabs>
 
 ### Creating Dev and Staging Schemas

--- a/pages/docs/guides/prod-staging-environments.mdx
+++ b/pages/docs/guides/prod-staging-environments.mdx
@@ -32,7 +32,7 @@ You can also use any dbt jinja or dbt macros to templatize or switch between dif
         type: attribute
         physicalName: sent_at
       - id: bounce_rate
-        type: metric
+        type: measure
         name: bounce rate
         formattingOptions:
           fixedDecimals: 0
@@ -42,23 +42,18 @@ You can also use any dbt jinja or dbt macros to templatize or switch between dif
   </Tab>
   <Tab>
   ```yaml dbt_project.yml copy {11}
-  
-  models:
-    +meta:
-      # hashboard-defaults settings will be merged into each Hashboard model
-      hashboard-defaults:
-        hbVersion: "1.0"
-        # preventUpdatesFromUI defaults to true, but can be set to false
-        preventUpdatesFromUI: false
-        source:
-          connectionName: bigquery-prod # you could also toggle the db connection
-          schema: "{{ target.schema }}"
-          # or you could do an env variable:
-          # schema: "{{ env_var('HB_SCHEMA_ENV') }}"
-          # OR a macro:
-          # schema: "{{ my_custom_macro(env) }}"
-  ```
-  </Tab>
+
+models:
++meta: # hashboard-defaults settings will be merged into each Hashboard model
+hashboard-defaults:
+hbVersion: "1.0" # preventUpdatesFromUI defaults to true, but can be set to false
+preventUpdatesFromUI: false
+source:
+connectionName: bigquery-prod # you could also toggle the db connection
+schema: "{{ target.schema }}" # or you could do an env variable: # schema: "{{ env_var('HB_SCHEMA_ENV') }}" # OR a macro: # schema: "{{ my_custom_macro(env) }}"
+
+```
+</Tab>
 </Tabs>
 
 ### Creating Dev and Staging Schemas
@@ -71,10 +66,10 @@ You can create a development schema within your database and specify this dev or
 - **continuous integration environments** - some systems like dbt cloud can create a new schema for each pull request in git, you can again create a new preview environment in hashboard that points at each of these different CI environments
 
 <Callout type="info">
-  *Prepending Table Names* - An alternative to creating a separate schema is to
-  prepend your table names with an environment indicator like `dev_`. This
-  allows you to easily distinguish between production and development tables in
-  the same schema.
+*Prepending Table Names* - An alternative to creating a separate schema is to
+prepend your table names with an environment indicator like `dev_`. This
+allows you to easily distinguish between production and development tables in
+the same schema.
 </Callout>
 
 ### Building Hashboard Previews
@@ -84,3 +79,4 @@ Once you have set up your dev schema or prepended your table names, you can buil
 Each preview acts as it's own ephemeral environment - so you don't just have a single staging environment, but an environment for any change that you can reference.
 
 </Steps>
+```

--- a/pages/docs/visualizing-data/controls/area-line-bar-controls.mdx
+++ b/pages/docs/visualizing-data/controls/area-line-bar-controls.mdx
@@ -17,7 +17,7 @@ For more information on how to use filters, see the [Filtering](../filter) docum
 This section contains options for customizing how your chart is displayed:
 
 - **Palette**: Sets the color scheme for the chart.
-- **Axis Labels**: Enables the display of attribute or metric names on the x and y axes.
+- **Axis Labels**: Enables the display of attribute or measure names on the x and y axes.
 - **Grid Lines**: Enables the display of grid lines for the x and y axes.
 - **Value labels**: Labels each datapoint with its numeric value.
 - **Legend**: Displays a color legend. When enabled, you can control the positioning of the legend by clicking Top, Right, Bottom, or Left, and you can also choose whether the legend title is displayed by toggling "Show Legend Title".

--- a/pages/docs/visualizing-data/controls/horizontal-bar-controls.mdx
+++ b/pages/docs/visualizing-data/controls/horizontal-bar-controls.mdx
@@ -17,7 +17,7 @@ For more information on how to use filters, see the [Filtering](../filter) docum
 This section contains options for customizing how your chart is displayed:
 
 - **Palette**: Sets the color scheme for the chart.
-- **Axis Labels**: Enables the display of attribute or metric names on the x and y axes.
+- **Axis Labels**: Enables the display of attribute or measure names on the x and y axes.
 - **Show Bar Labels**: Labels each datapoint with its numeric value.
 - **Legend**: Displays a color legend. When enabled, you can control the positioning of the legend by clicking Top, Right, Bottom, or Left, and you can also choose whether the legend title is displayed by toggling "Show Legend Title".
 


### PR DESCRIPTION
We have callouts about how "measures" used to be called "metrics", these are no longer relevant since our yml configs now use "measure" in all the appropriate places.