### PR TITLE
Pass in dbt-artifacts into `hb build` command in GitHub Action example

### DIFF
--- a/pages/docs/data-ops/continuous-integration/github-actions.mdx
+++ b/pages/docs/data-ops/continuous-integration/github-actions.mdx
@@ -141,7 +141,7 @@ jobs:
           HASHBOARD_ACCESS_KEY_ID: ${{ secrets.HASHBOARD_ACCESS_KEY_ID }}
           HASHBOARD_SECRET_ACCESS_KEY_TOKEN: ${{ secrets.HASHBOARD_SECRET_ACCESS_KEY_TOKEN }}
         run: |
-          hb build 2>&1 | tee out.txt
+          hb build --dbt-artifacts=./target 2>&1 | tee out.txt
           EXIT_CODE=${PIPESTATUS[0]}
           RESULT=$(cat out.txt | sed 's/`//g')
           URL=$(grep -o 'https://[^ ]*' out.txt)


### PR DESCRIPTION
Otherwise, this is not (necessarily) using the same target used in the `dbt build` command that happens right beforehand.