### PR TITLE
Serve embedded Hashboard docs from docs.hashboard.com

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_HASHBOARD_APP_BASE_URL=https://hashboard.com
+NEXT_PUBLIC_HASHBOARD_APP_BASE_URL=https://docs.hashboard.com


### PR DESCRIPTION
These are being proxied through Cloudfront now