### PR TITLE
[HB-11391] Add config schema for NumberFormat

### DIFF
--- a/pages/docs/data-ops/config-schema.mdx
+++ b/pages/docs/data-ops/config-schema.mdx
@@ -33,4 +33,9 @@ import { Card, Cards } from "nextra-theme-docs";
     title="Homepage Launchpad"
     href="/docs/data-ops/config-schema/homepage-launchpad"
   />
+  <Card
+    arrow
+    title="Number Format"
+    href="/docs/data-ops/config-schema/number-format"
+  />
 </Cards>

--- a/pages/docs/data-ops/config-schema/_meta.json
+++ b/pages/docs/data-ops/config-schema/_meta.json
@@ -4,5 +4,6 @@
   "metrics": {},
   "dashboards": {},
   "color-palettes": {},
-  "homepage-launchpad": {}
+  "homepage-launchpad": {},
+  "number-format": {}
 }

--- a/pages/docs/data-ops/config-schema/number-format.mdx
+++ b/pages/docs/data-ops/config-schema/number-format.mdx
@@ -1,0 +1,9 @@
+---
+description: Configuration schema for Number Format
+---
+
+import EmbedDocsFromHashboardApp from "/components/EmbedDocsFromHashboardApp";
+
+# Number Format
+
+<EmbedDocsFromHashboardApp path="publicResourceSpecs/NumberFormat" />

--- a/pages/docs/guides/prod-staging-environments.mdx
+++ b/pages/docs/guides/prod-staging-environments.mdx
@@ -34,9 +34,11 @@ You can also use any dbt jinja or dbt macros to templatize or switch between dif
       - id: bounce_rate
         type: measure
         name: bounce rate
-        formattingOptions:
-          fixedDecimals: 0
-          formatAsPercent: true
+        numberFormat:
+          style: percent
+          decimals:
+            min: 0
+            max: 0
         sql: safe_divide(sum(if(event_name='bounceResource',1,0)),count(distinct user_id))
     ```
   </Tab>


### PR DESCRIPTION
Related to https://github.com/gleannyc/glean/pull/13556

Adds a config schema item for NumberFormat. Unlike other schemas, this is not describing a resource with hbVersion/grn, rather a common struct that appears in multiple resource fields. Despite this, it seems like Configuration Schemas is the most reasonable place to put this.